### PR TITLE
[Tutorial: 5] [Integrate] iOS greeting

### DIFF
--- a/shared/src/commonMain/kotlin/cz/hlinka/kmpintegrationdemo/Greeter.kt
+++ b/shared/src/commonMain/kotlin/cz/hlinka/kmpintegrationdemo/Greeter.kt
@@ -4,6 +4,6 @@ class Greeter {
     private val platform: Platform = getPlatform()
 
     fun greet(): String {
-        return "Hello KMP from Android!"
+        return "Hello KMP from Android and iOS!"
     }
 }


### PR DESCRIPTION
Same as before (#2), but integrates the feature built on iOS.

Once merged, the backport is again pushed back to KMP main-android, acknowledging that we have adapted the changes from iOS.

Continue to: https://github.com/gohlinka2/KMPIntegrationDemoiOS/pull/3